### PR TITLE
use vars in git config

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -18,8 +18,8 @@ jobs:
         env:
           YOUTUBE_API_KEY: ${{ secrets.YOUTUBE_API_KEY }}
       - run: |
-          git config user.name carlosazaustre
-          git config user.email cazaustre@gmail.com
+          git config user.name $GIT_USER_NAME
+          git config user.email $GIT_USER_EMAIL
           git add data/latestVideos.json
           git diff --quiet && git diff --staged --quiet || git commit -m "[bot] Update latestVideos.json"
           git push origin main


### PR DESCRIPTION
To avoid triggerings with a personal account.

Every day I receive an email that this Action could not be executed because my account is used in another repository.
This way it is automatic by the repo owner.